### PR TITLE
Updated list of patterns to return a flowable response instead

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,6 +23,9 @@ ext {
       // Test Deps
       junit4         : "junit:junit:4.12",
       truth          : "com.google.truth:truth:0.34",
-      mockito        : "org.mockito:mockito-core:2.8.9"
+      mockito        : "org.mockito:mockito-core:2.8.9",
+
+      //RxJava
+      rxjava2        : "io.reactivex.rxjava2:rxjava:$rxjava2"
   ]
 }

--- a/retroravelry/build.gradle
+++ b/retroravelry/build.gradle
@@ -29,6 +29,8 @@ dependencies {
   compile dep.oauthServices
 
   compile dep.okhttp3
+  compile dep.rxjava2
+  compile dep.rxjavaAdapter
   testCompile dep.truth
   testCompile dep.junit4
   testCompile dep.mockito

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/RavelryApi.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/RavelryApi.kt
@@ -1,12 +1,13 @@
 package com.caseykulm.retroravelry
 
-import com.caseykulm.retroravelry.entities.Pattern
 import com.caseykulm.retroravelry.entities.Stash
 import com.caseykulm.retroravelry.network.responses.library.LibraryResponse
+import com.caseykulm.retroravelry.network.responses.patterns.SearchPatternsResponse
+import io.reactivex.Flowable
 import retrofit2.Call
 
 interface RavelryApi {
-  fun searchPatterns(query: String, page: Int, pageSize: Int): List<Pattern>
+  fun searchPatterns(query: String, page: Int, pageSize: Int): Flowable<SearchPatternsResponse>
   fun getMyStashes(): List<Stash>
   fun getStashes(username: String): List<Stash>
   fun getMyLibrary(

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/models/Paginator.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/models/Paginator.kt
@@ -3,9 +3,9 @@ package com.caseykulm.retroravelry.models
 import com.squareup.moshi.Json
 
 data class Paginator (
-        @Json(name="last_page") val lastPage: Int,
+        val last_page: Int,
         val page: Int,
-        @Json(name="page_count") val pageCount: Int,
-        @Json(name="page_size") val pageSize: Int,
+        val page_count: Int,
+        val page_size: Int,
         val results: Int
 )

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/network/RavelryRetroApi.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/network/RavelryRetroApi.kt
@@ -4,6 +4,7 @@ import com.caseykulm.retroravelry.network.responses.library.LibraryResponse
 import com.caseykulm.retroravelry.network.responses.patterns.SearchPatternsResponse
 import com.caseykulm.retroravelry.network.responses.patterns.ShowPatternResponse
 import com.caseykulm.retroravelry.network.responses.stash.StashesResponse
+import io.reactivex.Flowable
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -20,7 +21,7 @@ interface RavelryRetroApi {
       @Query("query") query: String,
       @Query("page") page: Int,
       @Query("page_size") pageSize: Int,
-      @Query("personal_attributes") personal_attributes: Boolean): Call<SearchPatternsResponse>
+      @Query("personal_attributes") personal_attributes: Boolean): Flowable<SearchPatternsResponse>
 
   @GET("patterns/{id}.json")
   fun showPattern(@Path("id") id: Int): Call<ShowPatternResponse>

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/RavelryClientTest.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/RavelryClientTest.kt
@@ -12,4 +12,10 @@ class RavelryClientTest {
     println(libResp)
     assertNotNull(libResp)
   }
+
+  @Test
+  fun searchPatternsShouldNotBeNull() {
+    val searchResponse = ravelryClient.searchPatterns("cardigan", 1, 20)
+    assertNotNull(searchResponse)
+  }
 }

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/RavelryClientTest.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/RavelryClientTest.kt
@@ -1,5 +1,6 @@
 package com.caseykulm.retroravelry
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
@@ -14,8 +15,18 @@ class RavelryClientTest {
   }
 
   @Test
-  fun searchPatternsShouldNotBeNull() {
+  fun searchPatternsShouldSubscribe() {
     val searchResponse = ravelryClient.searchPatterns("cardigan", 1, 20)
-    assertNotNull(searchResponse)
+    val testSubToSearch = searchResponse.test()
+    testSubToSearch.assertNoErrors()
+  }
+
+  @Test
+  fun searchPatternsShouldReturnResults() {
+    val searchResponse = ravelryClient.searchPatterns("cardigan", 1, 20)
+    val resp = searchResponse.blockingFirst()
+    println(resp)
+    assertNotNull(resp)
+    assertEquals(20, resp.paginator?.page_size)
   }
 }


### PR DESCRIPTION
Added RxJava call adapter to the retrofit builder to allow for flowable return for response. Added rxjava and rxjavaadapter imports to gradle, and refactored search to return flowable rather than list of patterns.