### PR TITLE
Inject logging interceptor rather than requiring it

### DIFF
--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/RavelryClient.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/RavelryClient.kt
@@ -13,7 +13,6 @@ import com.squareup.moshi.Rfc3339DateJsonAdapter
 import io.reactivex.Flowable
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -27,15 +26,11 @@ class RavelryClient(
   var ravelryRetroApi: RavelryRetroApi
 
   init {
-    //TODO inject moshi and logging interceptor
-    val logging = HttpLoggingInterceptor()
-    logging.level = HttpLoggingInterceptor.Level.BODY
     val moshi = Moshi.Builder()
         .add(Date::class.java, Rfc3339DateJsonAdapter())
         .add(KotlinJsonAdapterFactory())
         .build()
     val oauthClient = okHttpClient.newBuilder()
-        .addInterceptor(logging)
         .addInterceptor(oauth1Interceptor)
         .build()
     val retrofit = Retrofit.Builder()

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/LiveClient.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/LiveClient.kt
@@ -6,9 +6,16 @@ import com.caseykulm.oauthheader.models.AccessTokenResponse
 import com.caseykulm.oauthheader.models.OauthConsumer
 import com.caseykulm.oauthheader.services.RavelryOauthService
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 
 class LiveClient {
-  private val okhttpClient = OkHttpClient.Builder().build()
+  private val okhttpClient by lazy {
+    val logging = HttpLoggingInterceptor()
+    logging.level = HttpLoggingInterceptor.Level.BODY
+    OkHttpClient.Builder()
+        .addInterceptor(logging)
+        .build()
+  }
   private val oauthConsumer: OauthConsumer by lazy {
     OauthConsumer(
         oauthTestSecrets.consumerKey,

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/MockClient.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/MockClient.kt
@@ -6,6 +6,7 @@ import com.caseykulm.oauthheader.models.AccessTokenResponse
 import com.caseykulm.oauthheader.models.OauthConsumer
 import com.caseykulm.oauthheader.services.RavelryOauthService
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.mockwebserver.MockWebServer
 
 val MOCK_USER_NAME = "rumpletestuser"
@@ -20,8 +21,11 @@ class MockClient {
   val ravelryClient: RavelryClient by lazy {
     RavelryClient(MOCK_USER_NAME, okhttpClient, oauthInterceptor, server.url("/"))
   }
-  private val okhttpClient: OkHttpClient by lazy {
+  private val okhttpClient by lazy {
+    val logging = HttpLoggingInterceptor()
+    logging.level = HttpLoggingInterceptor.Level.BODY
     OkHttpClient.Builder()
+        .addInterceptor(logging)
         .build()
   }
   private val oauthInterceptor: Oauth1Interceptor by lazy {


### PR DESCRIPTION
* Removed `HttpLoggingInterceptor` from init block of `RavelryClient`
* Added `HttpLoggingInterceptor` to custom `OkHttpClient` objects in `LiveClient` and `MockClient` which are already being injected into `RavelryClient`

This resolves #10 