### PR TITLE
Abstract away auth providing to easily allow OAuth2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ buildscript {
 
     release = [
         'groupId': 'com.caseykulm.retroravelry',
-        'version': '0.7.0',
+        'version': '0.8.0',
         'description': 'Retrofit wrapper for the Ravelry REST API',
         'githubRepo': 'https://github.com/caseykulm/retroravelry',
         'secrets': [

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/RavelryClient.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/RavelryClient.kt
@@ -1,6 +1,7 @@
 package com.caseykulm.retroravelry
 
-import com.caseykulm.oauthheader.Oauth1Interceptor
+import com.caseykulm.retroravelry.auth.AuthProvider
+import com.caseykulm.retroravelry.auth.AuthorizationInterceptor
 import com.caseykulm.retroravelry.models.request.library.Sort
 import com.caseykulm.retroravelry.models.request.library.Type
 import com.caseykulm.retroravelry.network.RavelryRetroApi
@@ -13,7 +14,7 @@ import io.reactivex.Flowable
 import io.reactivex.Single
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
-import org.intellij.lang.annotations.Flow
+import okhttp3.Request
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.Result
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
@@ -23,7 +24,7 @@ import java.util.*
 private const val API_URL = "https://api.ravelry.com/"
 
 class RavelryClient(
-    oauth1Interceptor: Oauth1Interceptor,
+    authProvider: AuthProvider,
     okHttpClient: OkHttpClient, // TODO: Make this optional, and provide sensible defaults
     baseUrl: HttpUrl = HttpUrl.parse(API_URL)!! // TODO: Only reveal this as an option for tests
 ): RavelryApi {
@@ -35,7 +36,7 @@ class RavelryClient(
         .add(KotlinJsonAdapterFactory())
         .build()
     val oauthClient = okHttpClient.newBuilder()
-        .addInterceptor(oauth1Interceptor)
+        .addInterceptor(AuthorizationInterceptor(authProvider))
         .build()
     val retrofit = Retrofit.Builder()
         .baseUrl(baseUrl)

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/auth/AuthProvider.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/auth/AuthProvider.kt
@@ -1,0 +1,7 @@
+package com.caseykulm.retroravelry.auth
+
+import okhttp3.Request
+
+interface AuthProvider {
+    fun getAuthorizationHeaderValue(request: Request): String
+}

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/auth/AuthorizationInterceptor.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/auth/AuthorizationInterceptor.kt
@@ -1,0 +1,13 @@
+package com.caseykulm.retroravelry.auth
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthorizationInterceptor(private val authProvider: AuthProvider) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val signedRequest = chain.request().newBuilder()
+                .addHeader("Authorization", authProvider.getAuthorizationHeaderValue(chain.request()))
+                .build()
+        return chain.proceed(signedRequest)
+    }
+}

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/LiveClient.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/LiveClient.kt
@@ -1,11 +1,8 @@
 package com.caseykulm.retroravelry
 
-import com.caseykulm.oauthheader.Oauth1Client
-import com.caseykulm.oauthheader.Oauth1Interceptor
-import com.caseykulm.oauthheader.models.AccessTokenResponse
-import com.caseykulm.oauthheader.models.OauthConsumer
-import com.caseykulm.oauthheader.services.RavelryOauthService
+import com.caseykulm.retroravelry.auth.AuthProvider
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
 
 class LiveClient {
@@ -16,30 +13,17 @@ class LiveClient {
         .addInterceptor(logging)
         .build()
   }
-  private val oauthConsumer: OauthConsumer by lazy {
-    OauthConsumer(
-        oauthTestSecrets.consumerKey,
-        oauthTestSecrets.consumerSecret,
-        oauthTestSecrets.callbackUrl
-    )
-  }
-  private val oauthService = RavelryOauthService()
-  private val oauthClient: Oauth1Client by lazy {
-    Oauth1Client(
-        oauthConsumer,
-        oauthService,
-        okhttpClient
-    )
-  }
+
   // hardcoded
-  private val accessTokenResponse: AccessTokenResponse by lazy {
-    AccessTokenResponse(
-        oauthTestSecrets.accessToken,
-        oauthTestSecrets.accessTokenSecret
-    )
+  private val authProvider: AuthProvider by lazy {
+    object : AuthProvider {
+      override fun getAuthorizationHeaderValue(request: Request): String {
+        return "Bearer ${oauthTestSecrets.accessToken}"
+      }
+    }
   }
-  private val oauthInterceptor: Oauth1Interceptor by lazy { Oauth1Interceptor(oauthClient, accessTokenResponse) }
-  val ravelryClient: RavelryClient by lazy { RavelryClient(oauthInterceptor, okhttpClient) }
+
+  val ravelryClient: RavelryClient by lazy { RavelryClient(authProvider, okhttpClient) }
 
   private val oauthTestSecrets: OauthTestSecrets by lazy {
     parseJsonResourceFile("oauth_secrets.json", OauthTestSecrets::class.java)

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/MockClient.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/MockClient.kt
@@ -1,11 +1,8 @@
 package com.caseykulm.retroravelry
 
-import com.caseykulm.oauthheader.Oauth1Client
-import com.caseykulm.oauthheader.Oauth1Interceptor
-import com.caseykulm.oauthheader.models.AccessTokenResponse
-import com.caseykulm.oauthheader.models.OauthConsumer
-import com.caseykulm.oauthheader.services.RavelryOauthService
+import com.caseykulm.retroravelry.auth.AuthProvider
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.mockwebserver.MockWebServer
 
@@ -18,7 +15,7 @@ val MOCK_CALLBACK_URL = "https://example.com/oauth"
 
 class MockClient {
   var server: MockWebServer = MockWebServer()
-  val ravelryClient: RavelryClient by lazy { RavelryClient(oauthInterceptor, okhttpClient, server.url("/")) }
+  val ravelryClient: RavelryClient by lazy { RavelryClient(authProvider, okhttpClient, server.url("/")) }
   private val okhttpClient by lazy {
     val logging = HttpLoggingInterceptor()
     logging.level = HttpLoggingInterceptor.Level.BODY
@@ -26,21 +23,11 @@ class MockClient {
         .addInterceptor(logging)
         .build()
   }
-  private val oauthInterceptor: Oauth1Interceptor by lazy {
-    Oauth1Interceptor(oauthClient, accessTokenResponse)
+  private val authProvider: AuthProvider by lazy {
+    object : AuthProvider {
+      override fun getAuthorizationHeaderValue(request: Request): String {
+        return "Bearer $MOCK_ACCESS_TOKEN"
+      }
+    }
   }
-  private val oauthClient: Oauth1Client by lazy {
-    Oauth1Client(
-        oauthConsumer,
-        oauthService,
-        okhttpClient)
-  }
-  // hardcoded
-  private val accessTokenResponse: AccessTokenResponse by lazy {
-    AccessTokenResponse(MOCK_ACCESS_TOKEN,MOCK_ACCESS_TOKEN_SECRET)
-  }
-  private val oauthConsumer: OauthConsumer by lazy {
-    OauthConsumer(MOCK_CONSUMER_KEY, MOCK_CONSUMER_SECRET, MOCK_CALLBACK_URL)
-  }
-  private val oauthService = RavelryOauthService()
 }

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/RavelryClientTest.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/RavelryClientTest.kt
@@ -35,8 +35,11 @@ class RavelryClientTest {
     testSubToSearch.assertNoErrors()
   }
 
-  @Test @Ignore // TODO: Fix this test after implementing OAuth2
+  @Test
   fun `Given query with spaces, When search patterns rx, Then return results`() {
+    // arrange
+    mockClientRule.enqueueHttp200("search_patterns.json")
+
     val stubQuery = "baby hat"
 
     val searchResponse = testClient.searchPatternsRx(stubQuery, 1, 20)


### PR DESCRIPTION
We may or may not decide to move Ravelry specific OAuth code into here, but for now we should at the very least make the interface for the Authentication interceptor more abstract. This makes it very easy to migrate to OAuth2 which we have code for in our app already.

Note: The test have been refactored as well to work now, and 100% of the mocked tests pass, but the live client doesn't have 100% of it's tests passing simply because the username is incorrect. With OAuth2 on Ravelry the timeout on the token is significantly shorter, so make sure to update the `oauth_secrets.json` file daily if you want to run the live client tests.