### PR TITLE
Feature/ck oauth2 retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ buildscript {
 
     release = [
         'groupId': 'com.caseykulm.retroravelry',
-        'version': '0.9.0-CK-SNAPSHOT-1',
+        'version': '0.9.0',
         'description': 'Retrofit wrapper for the Ravelry REST API',
         'githubRepo': 'https://github.com/caseykulm/retroravelry',
         'secrets': [

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ buildscript {
 
     release = [
         'groupId': 'com.caseykulm.retroravelry',
-        'version': '0.8.0',
+        'version': '0.9.0-CK-SNAPSHOT-1',
         'description': 'Retrofit wrapper for the Ravelry REST API',
         'githubRepo': 'https://github.com/caseykulm/retroravelry',
         'secrets': [

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/RavelryClient.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/RavelryClient.kt
@@ -1,7 +1,7 @@
 package com.caseykulm.retroravelry
 
-import com.caseykulm.retroravelry.auth.AuthProvider
 import com.caseykulm.retroravelry.auth.AuthorizationInterceptor
+import com.caseykulm.retroravelry.auth.OAuth2Authenticator
 import com.caseykulm.retroravelry.models.request.library.Sort
 import com.caseykulm.retroravelry.models.request.library.Type
 import com.caseykulm.retroravelry.network.RavelryRetroApi
@@ -14,7 +14,6 @@ import io.reactivex.Flowable
 import io.reactivex.Single
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.Request
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.Result
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
@@ -24,7 +23,7 @@ import java.util.*
 private const val API_URL = "https://api.ravelry.com/"
 
 class RavelryClient(
-    authProvider: AuthProvider,
+    oAuth2Authenticator: OAuth2Authenticator,
     okHttpClient: OkHttpClient, // TODO: Make this optional, and provide sensible defaults
     baseUrl: HttpUrl = HttpUrl.parse(API_URL)!! // TODO: Only reveal this as an option for tests
 ): RavelryApi {
@@ -36,7 +35,7 @@ class RavelryClient(
         .add(KotlinJsonAdapterFactory())
         .build()
     val oauthClient = okHttpClient.newBuilder()
-        .addInterceptor(AuthorizationInterceptor(authProvider))
+        .addInterceptor(AuthorizationInterceptor(oAuth2Authenticator))
         .build()
     val retrofit = Retrofit.Builder()
         .baseUrl(baseUrl)

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/auth/AuthenticationHeaderProvider.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/auth/AuthenticationHeaderProvider.kt
@@ -2,6 +2,6 @@ package com.caseykulm.retroravelry.auth
 
 import okhttp3.Request
 
-interface AuthProvider {
+interface AuthenticationHeaderProvider {
     fun getAuthorizationHeaderValue(request: Request): String
 }

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/auth/AuthorizationInterceptor.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/auth/AuthorizationInterceptor.kt
@@ -3,11 +3,55 @@ package com.caseykulm.retroravelry.auth
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class AuthorizationInterceptor(private val authProvider: AuthProvider) : Interceptor {
+interface OAuth2Authenticator {
+    /**
+     * Should provide the value for the Authorization header.
+     */
+    val authHeaderProvider: AuthenticationHeaderProvider
+
+    /**
+     * Checks local cached timestamp to preemptively know to refresh rather than relying on a 401 to return.
+     */
+    fun isExpired(): Boolean
+
+    /**
+     * Does the work necessary to update the cached version of the Access Token, Refresh Token, and Timestamp
+     */
+    fun refresh(): Boolean
+
+    /**
+     * Notification so that we can bail appropriately
+     */
+    fun onRefreshFailed()
+}
+
+class AuthorizationInterceptor(private val oAuth2Manager: OAuth2Authenticator) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
+        checkIfExpired()
+
         val signedRequest = chain.request().newBuilder()
-                .addHeader("Authorization", authProvider.getAuthorizationHeaderValue(chain.request()))
-                .build()
-        return chain.proceed(signedRequest)
+            .addHeader("Authorization", oAuth2Manager.authHeaderProvider
+                .getAuthorizationHeaderValue(chain.request()))
+            .build()
+        val resp = chain.proceed(signedRequest)
+
+        if (resp.code() == 401) {
+            refresh()
+        }
+
+        return resp
+    }
+
+    private fun checkIfExpired() = when (oAuth2Manager.isExpired()) {
+        true -> refresh()
+        false -> { /* all good, proceed */ }
+    }
+
+    private fun refresh() = when (oAuth2Manager.refresh()) {
+        true -> { /* successfully refreshed, all good, proceed */ }
+        false -> {
+            /* refresh failed, notify OAuth2Authenticator so it can bail appropriately */
+            oAuth2Manager.onRefreshFailed()
+        }
     }
 }

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/LiveClient.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/LiveClient.kt
@@ -1,6 +1,7 @@
 package com.caseykulm.retroravelry
 
 import com.caseykulm.retroravelry.auth.AuthenticationHeaderProvider
+import com.caseykulm.retroravelry.auth.OAuth2Authenticator
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
@@ -22,8 +23,26 @@ class LiveClient {
       }
     }
   }
+  private val oAuth2Authenticator: OAuth2Authenticator by lazy {
+    object : OAuth2Authenticator {
+      override val authHeaderProvider: AuthenticationHeaderProvider
+        get() = authHeaderProvider
 
-  val ravelryClient: RavelryClient by lazy { RavelryClient(authenticationHeaderProvider, okhttpClient) }
+      override fun isExpired(): Boolean {
+        return false
+      }
+
+      override fun refresh(): Boolean {
+        return true
+      }
+
+      override fun onRefreshFailed() {
+        /* no-op */
+      }
+    }
+  }
+
+  val ravelryClient: RavelryClient by lazy { RavelryClient(oAuth2Authenticator, okhttpClient) }
 
   private val oauthTestSecrets: OauthTestSecrets by lazy {
     parseJsonResourceFile("oauth_secrets.json", OauthTestSecrets::class.java)

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/LiveClient.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/LiveClient.kt
@@ -1,6 +1,6 @@
 package com.caseykulm.retroravelry
 
-import com.caseykulm.retroravelry.auth.AuthProvider
+import com.caseykulm.retroravelry.auth.AuthenticationHeaderProvider
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
@@ -15,15 +15,15 @@ class LiveClient {
   }
 
   // hardcoded
-  private val authProvider: AuthProvider by lazy {
-    object : AuthProvider {
+  private val authenticationHeaderProvider: AuthenticationHeaderProvider by lazy {
+    object : AuthenticationHeaderProvider {
       override fun getAuthorizationHeaderValue(request: Request): String {
         return "Bearer ${oauthTestSecrets.accessToken}"
       }
     }
   }
 
-  val ravelryClient: RavelryClient by lazy { RavelryClient(authProvider, okhttpClient) }
+  val ravelryClient: RavelryClient by lazy { RavelryClient(authenticationHeaderProvider, okhttpClient) }
 
   private val oauthTestSecrets: OauthTestSecrets by lazy {
     parseJsonResourceFile("oauth_secrets.json", OauthTestSecrets::class.java)

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/MockClient.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/MockClient.kt
@@ -1,6 +1,7 @@
 package com.caseykulm.retroravelry
 
 import com.caseykulm.retroravelry.auth.AuthenticationHeaderProvider
+import com.caseykulm.retroravelry.auth.OAuth2Authenticator
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
@@ -15,7 +16,7 @@ val MOCK_CALLBACK_URL = "https://example.com/oauth"
 
 class MockClient {
   var server: MockWebServer = MockWebServer()
-  val ravelryClient: RavelryClient by lazy { RavelryClient(authenticationHeaderProvider, okhttpClient, server.url("/")) }
+  val ravelryClient: RavelryClient by lazy { RavelryClient(oAuth2Authenticator, okhttpClient, server.url("/")) }
   private val okhttpClient by lazy {
     val logging = HttpLoggingInterceptor()
     logging.level = HttpLoggingInterceptor.Level.BODY
@@ -27,6 +28,24 @@ class MockClient {
     object : AuthenticationHeaderProvider {
       override fun getAuthorizationHeaderValue(request: Request): String {
         return "Bearer $MOCK_ACCESS_TOKEN"
+      }
+    }
+  }
+  private val oAuth2Authenticator: OAuth2Authenticator by lazy {
+    object : OAuth2Authenticator {
+      override val authHeaderProvider: AuthenticationHeaderProvider
+        get() = authenticationHeaderProvider
+
+      override fun isExpired(): Boolean {
+        return false
+      }
+
+      override fun refresh(): Boolean {
+        return true
+      }
+
+      override fun onRefreshFailed() {
+        /* no-op */
       }
     }
   }

--- a/retroravelry/src/test/java/com/caseykulm/retroravelry/MockClient.kt
+++ b/retroravelry/src/test/java/com/caseykulm/retroravelry/MockClient.kt
@@ -1,6 +1,6 @@
 package com.caseykulm.retroravelry
 
-import com.caseykulm.retroravelry.auth.AuthProvider
+import com.caseykulm.retroravelry.auth.AuthenticationHeaderProvider
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
@@ -15,7 +15,7 @@ val MOCK_CALLBACK_URL = "https://example.com/oauth"
 
 class MockClient {
   var server: MockWebServer = MockWebServer()
-  val ravelryClient: RavelryClient by lazy { RavelryClient(authProvider, okhttpClient, server.url("/")) }
+  val ravelryClient: RavelryClient by lazy { RavelryClient(authenticationHeaderProvider, okhttpClient, server.url("/")) }
   private val okhttpClient by lazy {
     val logging = HttpLoggingInterceptor()
     logging.level = HttpLoggingInterceptor.Level.BODY
@@ -23,8 +23,8 @@ class MockClient {
         .addInterceptor(logging)
         .build()
   }
-  private val authProvider: AuthProvider by lazy {
-    object : AuthProvider {
+  private val authenticationHeaderProvider: AuthenticationHeaderProvider by lazy {
+    object : AuthenticationHeaderProvider {
       override fun getAuthorizationHeaderValue(request: Request): String {
         return "Bearer $MOCK_ACCESS_TOKEN"
       }


### PR DESCRIPTION
Went back to hard coding the name since refresh is a detail of OAuth2 that didn't exist for the OAuth1 Authentication, but I did introduce an `OAuth2Authenticator` interface to at least help separate the implementation. The implementation of OAuth2 still doesn't live here yet, but it might make sense.