### PR TITLE
Moshi enum cleanup, and buildSrc cleanup

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 repositories {
     jcenter()
     mavenCentral()
@@ -11,15 +9,6 @@ plugins {
     `java-gradle-plugin`
     kotlin("jvm") version "1.4.10"
     kotlin("kapt") version "1.4.10"
-}
-
-val compileKotlin: KotlinCompile by tasks
-compileKotlin.kotlinOptions {
-    jvmTarget = "1.8"
-}
-val compileTestKotlin: KotlinCompile by tasks
-compileTestKotlin.kotlinOptions {
-    jvmTarget = "1.8"
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/kotlin/com/caseykulm/retroravelry/gradle/ProjectKtx.kt
+++ b/buildSrc/src/main/kotlin/com/caseykulm/retroravelry/gradle/ProjectKtx.kt
@@ -10,14 +10,14 @@ fun Project.loadProperties(fileName: String): Properties = Properties().apply {
 
 fun Project.getSystemVariableOrGradleProperty(name: String, gradleFileName: String): String {
     val prop: String = if (System.getenv()[name] != null) {
-        print("Checking for $name in shell system variables... ")
+        // print("Checking for $name in shell system variables... ")
         val sysVar: String = System.getenv()[name] ?: throw IllegalStateException("Failed to parse system variable $name")
-        println("Found!")
+        // println("Found!")
         sysVar
     } else {
-        print("Checking for $name in $gradleFileName... ")
+        // print("Checking for $name in $gradleFileName... ")
         val gradleVar = loadProperties(gradleFileName).getProperty(name)
-        println("Found!")
+        // println("Found!")
         gradleVar
     }
 

--- a/buildSrc/src/main/kotlin/com/caseykulm/retroravelry/gradle/constants/Deps.kt
+++ b/buildSrc/src/main/kotlin/com/caseykulm/retroravelry/gradle/constants/Deps.kt
@@ -10,7 +10,6 @@ object Deps {
         const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinx}"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
         const val jdk8 = "stdlib-jdk8"
-        const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
         const val test = "org.jetbrains.kotlin:kotlin-test:${Versions.kotlin}"
         const val testCommon = "org.jetbrains.kotlin:kotlin-test-common:${Versions.kotlin}"
         const val testJunit5 = "org.jetbrains.kotlin:kotlin-test-junit5:${Versions.kotlin}"

--- a/buildSrc/src/main/kotlin/com/caseykulm/retroravelry/gradle/constants/Versions.kt
+++ b/buildSrc/src/main/kotlin/com/caseykulm/retroravelry/gradle/constants/Versions.kt
@@ -4,10 +4,11 @@ object Versions {
     const val junit5 = "5.6.2"
     const val kotlin = "1.4.10"
     const val kotlinx = "1.3.9"
+    const val ktlint = "0.39.0"
     const val mockito = "3.0.0"
-    const val moshi = "1.9.3"
+    const val moshi = "1.11.0"
     const val okhttp3 = "3.14.4"
-    const val retrofit = "2.6.2"
+    const val retrofit = "2.9.0"
     const val retroravelry = "0.10.0"
     const val rxjava2 = "2.2.15"
 }

--- a/buildSrc/src/main/kotlin/com/caseykulm/retroravelry/gradle/plugins/RetroRavelryPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/caseykulm/retroravelry/gradle/plugins/RetroRavelryPlugin.kt
@@ -9,9 +9,12 @@ import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.KotlinBuildScript
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 import java.util.Date
 
@@ -25,6 +28,7 @@ class RetroRavelryPlugin : Plugin<Project> {
             configureBintrayPlugin(project, loadRetroRavelrySecrets())
             configureJunit5()
             configureKapt()
+            configureKotlin()
         }
     }
 }
@@ -182,5 +186,13 @@ private fun Project.configureJunit5() {
 private fun Project.configureKapt() {
     configure<KaptExtension> {
         useBuildCache = true
+    }
+}
+
+private fun Project.configureKotlin() {
+    tasks.withType<KotlinCompile>().configureEach {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
     }
 }

--- a/retroravelry/build.gradle.kts
+++ b/retroravelry/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.caseykulm.retroravelry.gradle.constants.Deps
+import com.caseykulm.retroravelry.gradle.constants.Versions
 
 repositories {
     maven("https://plugins.gradle.org/m2/")
@@ -19,14 +20,13 @@ plugins {
 
 // Cannot currently move this to buildSrc because of https://github.com/JLLeitschuh/ktlint-gradle/issues/239
 ktlint {
-    version.set("0.39.0")
+    version.set(Versions.ktlint)
     android.set(false)
 }
 
 dependencies {
     implementation(Deps.Kotlin.core)
     implementation(Deps.Kotlin.coroutines)
-    implementation(Deps.Kotlin.reflect)
     implementation(Deps.Moshi.core)
     implementation(Deps.Moshi.kotlin)
     implementation(Deps.Moshi.adapters)

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/MoshiEnumConverterFactory.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/MoshiEnumConverterFactory.kt
@@ -1,0 +1,37 @@
+package com.caseykulm.retroravelry
+
+import com.squareup.moshi.Json
+import retrofit2.Converter
+import retrofit2.Retrofit
+import java.lang.reflect.Type
+
+/**
+ * Converter factory for moshi Json annotations on enums so that the same annotations can be used for the Retrofit Service interface parameters.
+ *
+ */
+class MoshiEnumConverterFactory : Converter.Factory() {
+    override fun stringConverter(
+        type: Type,
+        annotations: Array<Annotation>,
+        retrofit: Retrofit
+    ): Converter<Any, String>? {
+        var converter: Converter<Any, String>? = null
+        if (type is Class<*> && type.isEnum) {
+            converter = Converter { value: Any -> getJsonName(type, value as Enum<*>) }
+        }
+        return converter
+    }
+}
+
+private fun getJsonName(type: Type, e: Enum<*>): String? {
+    var value: String? = null
+    try {
+        value = e::class.java.fields
+            .first { it.type == type && it.name == e.name }
+            .getAnnotation(Json::class.java)
+            .name
+    } catch (throwable: Throwable) {
+        throwable.printStackTrace()
+    }
+    return value
+}

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/RavelryApi.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/RavelryApi.kt
@@ -33,16 +33,16 @@ interface RavelryApi {
     suspend fun getUserLibrary(
         username: String,
         query: String,
-        queryType: String?,
-        type: Type?,
-        sort: Sort?,
         page: Int,
-        pageSize: Int
+        pageSize: Int,
+        queryType: String? = null,
+        type: Type? = null,
+        sort: Sort? = null,
     ): LibraryResponse
 
     @Deprecated(
         message = "Deprecating the RxJava2 API in favor of Kotlin Coroutines",
-        replaceWith = ReplaceWith(expression = "getUserLibrary(username, query, queryType, type, sort, page, pageSize)")
+        replaceWith = ReplaceWith(expression = "getUserLibrary(username, query, page, pageSize, queryType, type, sort)")
     )
     fun searchLibraryRx(
         username: String,

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/models/request/library/QueryType.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/models/request/library/QueryType.kt
@@ -1,0 +1,8 @@
+package com.caseykulm.retroravelry.models.request.library
+
+import com.squareup.moshi.Json
+
+enum class QueryType {
+    @Json(name = "patterns") Patterns,
+    @Json(name = "tags") Tags
+}

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/models/request/library/Sort.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/models/request/library/Sort.kt
@@ -1,11 +1,13 @@
 package com.caseykulm.retroravelry.models.request.library
 
+import com.squareup.moshi.Json
+
 /**
  * Created by lorajones on 10/15/17.
  */
 enum class Sort {
-    Title,
-    Added,
-    Published,
-    Author
+    @Json(name = "title") Title,
+    @Json(name = "added") Added,
+    @Json(name = "published") Published,
+    @Json(name = "author") Author
 }

--- a/retroravelry/src/main/java/com/caseykulm/retroravelry/models/request/library/Type.kt
+++ b/retroravelry/src/main/java/com/caseykulm/retroravelry/models/request/library/Type.kt
@@ -1,12 +1,14 @@
 package com.caseykulm.retroravelry.models.request.library
 
+import com.squareup.moshi.Json
+
 /**
  * Created by lorajones on 10/15/17.
  */
 enum class Type {
-    Book,
-    Magazine,
-    Booklet,
-    Pattern,
-    Pdf
+    @Json(name = "book") Book,
+    @Json(name = "magazine") Magazine,
+    @Json(name = "booklet") Booklet,
+    @Json(name = "pattern") Pattern,
+    @Json(name = "pdf") Pdf
 }


### PR DESCRIPTION
* Removed kotlin-reflect
* Added `MoshiEnumConverterFactory` which is a Moshi string converter to allow enums passed to Retrofit to use the `@Json` annotation
* Added target jvm in buildSrc
* Added `@Json` annotations to the enums